### PR TITLE
Fix connection error handling

### DIFF
--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -39,6 +39,7 @@ var migrateCmd = &cobra.Command{
 		if err != nil {
 			// if db does not exist, try creating it
 			pqError, ok := err.(*pq.Error)
+			logger.Warnf(ctx, "%s", pqError)
 			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/lib/pq"
+	"reflect"
 
 	"context"
 
@@ -38,9 +39,10 @@ var migrateCmd = &cobra.Command{
 
 		if err != nil {
 			// if db does not exist, try creating it
-			pqError, ok := err.(*pq.Error)
+ 			pqError, ok := err.(*pq.Error)
 			logger.Errorf(ctx, "pqError code: %s", pqError)
 			logger.Errorf(ctx, "ok: %v", ok)
+ 			logger.Errorf(ctx, "error type: %v", reflect.TypeOf(err))
 			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -1,6 +1,8 @@
 package entrypoints
 
 import (
+	"reflect"
+
 	"github.com/flyteorg/datacatalog/pkg/repositories"
 	errors2 "github.com/flyteorg/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/datacatalog/pkg/runtime"
@@ -41,8 +43,13 @@ var migrateCmd = &cobra.Command{
 		if err != nil {
 			// if db does not exist, try creating it
 			cErr, ok := err.(errors2.ConnectError)
+			if !ok {
+				logger.Errorf(ctx, "Failed to cast error of type: %v, err: %v", reflect.TypeOf(err),
+					err)
+				panic(err)
+			}
 			pqError := cErr.Unwrap().(*pgconn.PgError)
-			if ok && pqError.Code == pqInvalidDBCode {
+			if pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 
 				dbConfigValues.DbName = defaultDB

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -3,6 +3,7 @@ package entrypoints
 import (
 	"github.com/flyteorg/datacatalog/pkg/repositories"
 	"github.com/flyteorg/datacatalog/pkg/runtime"
+	"github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 
@@ -44,7 +45,12 @@ var migrateCmd = &cobra.Command{
 			logger.Errorf(ctx, "pqError code: %s", pqError)
 			logger.Errorf(ctx, "ok: %v", ok)
  			logger.Errorf(ctx, "error type: %v", reflect.TypeOf(err))
-			if ok && pqError.Code == pqInvalidDBCode {
+
+			code, ok := errors.GetErrorCode(err)
+			logger.Errorf(ctx, "Error code: %s", code)
+			logger.Errorf(ctx, "ok: %v", ok)
+
+ 			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 
 				dbConfigValues.DbName = defaultDB

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -4,12 +4,10 @@ import (
 	"github.com/flyteorg/datacatalog/pkg/repositories"
 	errors2 "github.com/flyteorg/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/datacatalog/pkg/runtime"
-	"github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 
 	"github.com/jackc/pgconn"
-	"reflect"
 
 	"context"
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -5,7 +5,7 @@ import (
 	"github.com/flyteorg/datacatalog/pkg/runtime"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
-	"github.com/lib/pq"
+
 	"github.com/jackc/pgconn"
 	"reflect"
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -39,7 +39,8 @@ var migrateCmd = &cobra.Command{
 		if err != nil {
 			// if db does not exist, try creating it
 			pqError, ok := err.(*pq.Error)
-			logger.Warnf(ctx, "%s", pqError)
+			logger.Errorf(ctx, "pqError code: %s", pqError)
+			logger.Errorf(ctx, "ok: %v", ok)
 			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -41,12 +41,7 @@ var migrateCmd = &cobra.Command{
 		if err != nil {
 			// if db does not exist, try creating it
  			cErr, ok := err.(errors2.ConnectError)
-			logger.Errorf(ctx, "ok: %v", ok)
-
 			pqError := cErr.Unwrap().(*pgconn.PgError)
-			logger.Errorf(ctx, "Error code: %s", pqError.Code)
-			logger.Errorf(ctx, "ok: %v", ok)
-
  			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -40,9 +40,9 @@ var migrateCmd = &cobra.Command{
 
 		if err != nil {
 			// if db does not exist, try creating it
- 			cErr, ok := err.(errors2.ConnectError)
+			cErr, ok := err.(errors2.ConnectError)
 			pqError := cErr.Unwrap().(*pgconn.PgError)
- 			if ok && pqError.Code == pqInvalidDBCode {
+			if ok && pqError.Code == pqInvalidDBCode {
 				logger.Warningf(ctx, "Database [%v] does not exist, trying to create it now", dbName)
 
 				dbConfigValues.DbName = defaultDB

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -2,6 +2,7 @@ package entrypoints
 
 import (
 	"github.com/flyteorg/datacatalog/pkg/repositories"
+	errors2 "github.com/flyteorg/datacatalog/pkg/repositories/errors"
 	"github.com/flyteorg/datacatalog/pkg/runtime"
 	"github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -41,13 +42,11 @@ var migrateCmd = &cobra.Command{
 
 		if err != nil {
 			// if db does not exist, try creating it
- 			pqError, ok := err.(*pgconn.PgError)
-			logger.Errorf(ctx, "pqError code: %s", pqError)
+ 			cErr, ok := err.(errors2.ConnectError)
 			logger.Errorf(ctx, "ok: %v", ok)
- 			logger.Errorf(ctx, "error type: %v", reflect.TypeOf(err))
 
-			code, ok := errors.GetErrorCode(err)
-			logger.Errorf(ctx, "Error code: %s", code)
+			pqError := cErr.Unwrap().(*pgconn.PgError)
+			logger.Errorf(ctx, "Error code: %s", pqError.Code)
 			logger.Errorf(ctx, "ok: %v", ok)
 
  			if ok && pqError.Code == pqInvalidDBCode {

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/lib/pq"
+	"github.com/jackc/pgconn"
 	"reflect"
 
 	"context"
@@ -39,7 +40,7 @@ var migrateCmd = &cobra.Command{
 
 		if err != nil {
 			// if db does not exist, try creating it
- 			pqError, ok := err.(*pq.Error)
+ 			pqError, ok := err.(*pgconn.PgError)
 			logger.Errorf(ctx, "pqError code: %s", pqError)
 			logger.Errorf(ctx, "ok: %v", ok)
  			logger.Errorf(ctx, "error type: %v", reflect.TypeOf(err))

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/flyteorg/flytestdlib v0.3.13
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3
-	github.com/lib/pq v1.3.0
+	github.com/jackc/pgconn v1.8.1
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5

--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -52,3 +52,8 @@ func (p *postgresErrorTransformer) ToDataCatalogError(err error) error {
 func NewPostgresErrorTransformer() ErrorTransformer {
 	return &postgresErrorTransformer{}
 }
+
+type ConnectError interface {
+	Unwrap() error
+	Error() string
+}

--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+
 	"github.com/jackc/pgconn"
 
 	"github.com/flyteorg/datacatalog/pkg/errors"

--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -37,10 +37,10 @@ func (p *postgresErrorTransformer) fromGormError(err error) error {
 
 func (p *postgresErrorTransformer) ToDataCatalogError(err error) error {
 	cErr, ok := err.(ConnectError)
-	pqError := cErr.Unwrap().(*pgconn.PgError)
 	if !ok {
 		return p.fromGormError(err)
 	}
+	pqError := cErr.Unwrap().(*pgconn.PgError)
 	switch pqError.Code {
 	case uniqueConstraintViolationCode:
 		return errors.NewDataCatalogErrorf(codes.AlreadyExists, uniqueConstraintViolation, pqError.Message)

--- a/pkg/repositories/gormimpl/tag_test.go
+++ b/pkg/repositories/gormimpl/tag_test.go
@@ -1,6 +1,7 @@
 package gormimpl
 
 import (
+	"github.com/jackc/pgconn"
 	"testing"
 
 	"gorm.io/gorm"
@@ -20,7 +21,6 @@ import (
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
-	"github.com/lib/pq"
 	"google.golang.org/grpc/codes"
 )
 
@@ -28,8 +28,25 @@ func init() {
 	labeled.SetMetricKeys(contextutils.AppNameKey)
 }
 
+
+type pgError struct {
+	e error
+	msg string
+}
+
+func (p *pgError) Error() string {
+	return p.msg
+}
+
+func (p *pgError) Unwrap() error {
+	return p.e
+}
+
 func getAlreadyExistsErr() error {
-	return &pq.Error{Code: "23505"}
+	return &pgError{
+		e:   &pgconn.PgError{Code: "23505"},
+		msg: "some error",
+	}
 }
 
 func getTestTag() models.Tag {

--- a/pkg/repositories/gormimpl/tag_test.go
+++ b/pkg/repositories/gormimpl/tag_test.go
@@ -1,8 +1,9 @@
 package gormimpl
 
 import (
-	"github.com/jackc/pgconn"
 	"testing"
+
+	"github.com/jackc/pgconn"
 
 	"gorm.io/gorm"
 
@@ -28,9 +29,8 @@ func init() {
 	labeled.SetMetricKeys(contextutils.AppNameKey)
 }
 
-
 type pgError struct {
-	e error
+	e   error
 	msg string
 }
 


### PR DESCRIPTION
# TL;DR
Fix error handling for postgres connection error.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Gorm in the latest version switched the postgres connection library (from `github.com/lib/pq` to `github.com/jackc/pgconn`) and breaks the connection error handling in datacatalog.

And that is also causing issue the error handling in migration process. In https://github.com/flyteorg/datacatalog/blob/master/cmd/entrypoints/migrate.go#L42, the migration process should create the db if it does not exist but the error handling issue is causing it not to do so:
```
{"json":{"src":"migrate.go:67"},"level":"error","msg":"Failed to connect DB err failed to connect to `host=postgres user=postgres database=datacatalog`: server error (FATAL: database \"datacatalog\" does not exist (SQLSTATE 3D000))","ts":"2021-06-04T16:38:43Z"}
panic: failed to connect to `host=postgres user=postgres database=datacatalog`: server error (FATAL: database "datacatalog" does not exist (SQLSTATE 3D000))
goroutine 1 [running]:
github.com/flyteorg/datacatalog/cmd/entrypoints.glob..func1(0x2222a20, 0xc00021e820, 0x0, 0x2)
    /go/src/github.com/lyft/datacatalog/cmd/entrypoints/migrate.go:68 +0x987
github.com/spf13/cobra.(*Command).execute(0x2222a20, 0xc00021e800, 0x2, 0x2, 0x2222a20, 0xc00021e800)
    /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x2aa
github.com/spf13/cobra.(*Command).ExecuteC(0x2222cc0, 0x14d1c6f, 0x1, 0xffffffffffffffff)
    /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
    /go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/flyteorg/datacatalog/cmd/entrypoints.Execute(0xc000000002, 0x405700)
    /go/src/github.com/lyft/datacatalog/cmd/entrypoints/root.go:44 +0x31
main.main()
    /go/src/github.com/lyft/datacatalog/cmd/main.go:10 +0x59
```

I did not catch this issue earlier in the sandbox testing because before I switched the datacatalog version, the migration process already creates the db hence I did not run into db not exist error. This time, I tried to re-create the postgres server before I run the latest datacatalog version and I can verify that the migration process succeeds. 

## Tracking Issue
NA

## Follow-up issue
NA
