### PR TITLE
Fix gorm wrong error type cast

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -434,7 +434,6 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -686,7 +685,6 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
@@ -767,7 +765,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/pkg/manager/impl/artifact_manager.go
+++ b/pkg/manager/impl/artifact_manager.go
@@ -161,7 +161,7 @@ func (m *artifactManager) GetArtifact(ctx context.Context, request *datacatalog.
 
 		if err != nil {
 			if errors.IsDoesNotExistError(err) {
-				logger.Warnf(ctx, "Artifact does not exist tag: %+v, err %v", request.GetTagName(), err)
+				logger.Infof(ctx, "Artifact does not exist tag: %+v, err %v", request.GetTagName(), err)
 				m.systemMetrics.doesNotExistCounter.Inc(ctx)
 			} else {
 				logger.Errorf(ctx, "Unable to retrieve Artifact by tag %v, err: %v", request.GetTagName(), err)

--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -1,7 +1,7 @@
 package errors
 
 import (
-	errors2 "errors"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -9,7 +9,7 @@ import (
 
 	"github.com/jackc/pgconn"
 
-	"github.com/flyteorg/datacatalog/pkg/errors"
+	catalogErrors "github.com/flyteorg/datacatalog/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"gorm.io/gorm"
 )
@@ -33,14 +33,14 @@ const (
 func (p *postgresErrorTransformer) fromGormError(err error) error {
 	switch err.Error() {
 	case gorm.ErrRecordNotFound.Error():
-		return errors.NewDataCatalogErrorf(codes.NotFound, "entry not found")
+		return catalogErrors.NewDataCatalogErrorf(codes.NotFound, "entry not found")
 	default:
-		return errors.NewDataCatalogErrorf(codes.Internal, unexpectedType, err)
+		return catalogErrors.NewDataCatalogErrorf(codes.Internal, unexpectedType, err)
 	}
 }
 
 func (p *postgresErrorTransformer) ToDataCatalogError(err error) error {
-	if unwrappedErr := errors2.Unwrap(err); unwrappedErr != nil {
+	if unwrappedErr := errors.Unwrap(err); unwrappedErr != nil {
 		err = unwrappedErr
 	}
 
@@ -53,11 +53,11 @@ func (p *postgresErrorTransformer) ToDataCatalogError(err error) error {
 
 	switch pqError.Code {
 	case uniqueConstraintViolationCode:
-		return errors.NewDataCatalogErrorf(codes.AlreadyExists, uniqueConstraintViolation, pqError.Message)
+		return catalogErrors.NewDataCatalogErrorf(codes.AlreadyExists, uniqueConstraintViolation, pqError.Message)
 	case undefinedTable:
-		return errors.NewDataCatalogErrorf(codes.InvalidArgument, unsupportedTableOperation, pqError.Message)
+		return catalogErrors.NewDataCatalogErrorf(codes.InvalidArgument, unsupportedTableOperation, pqError.Message)
 	default:
-		return errors.NewDataCatalogErrorf(codes.Unknown, fmt.Sprintf(defaultPgError, pqError.Code, pqError.Message))
+		return catalogErrors.NewDataCatalogErrorf(codes.Unknown, fmt.Sprintf(defaultPgError, pqError.Code, pqError.Message))
 	}
 }
 

--- a/pkg/repositories/errors/postgres.go
+++ b/pkg/repositories/errors/postgres.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	errors2 "errors"
 	"fmt"
 	"reflect"
 
@@ -39,6 +40,10 @@ func (p *postgresErrorTransformer) fromGormError(err error) error {
 }
 
 func (p *postgresErrorTransformer) ToDataCatalogError(err error) error {
+	if unwrappedErr := errors2.Unwrap(err); unwrappedErr != nil {
+		err = unwrappedErr
+	}
+
 	pqError, ok := err.(*pgconn.PgError)
 	if !ok {
 		logger.InfofNoCtx("Unable to cast to pgconn.PgError. Error type: [%v]",

--- a/pkg/repositories/gormimpl/artifact_test.go
+++ b/pkg/repositories/gormimpl/artifact_test.go
@@ -275,7 +275,7 @@ func TestCreateArtifactAlreadyExists(t *testing.T) {
 	assert.Error(t, err)
 	dcErr, ok := err.(apiErrors.DataCatalogError)
 	assert.True(t, ok)
-	assert.Equal(t, dcErr.Code(), codes.AlreadyExists)
+	assert.Equal(t, dcErr.Code().String(), codes.AlreadyExists.String())
 }
 
 func TestListArtifactsWithPartition(t *testing.T) {

--- a/pkg/repositories/gormimpl/dataset_test.go
+++ b/pkg/repositories/gormimpl/dataset_test.go
@@ -246,7 +246,7 @@ func TestCreateDatasetAlreadyExists(t *testing.T) {
 	assert.Error(t, err)
 	dcErr, ok := err.(datacatalog_error.DataCatalogError)
 	assert.True(t, ok)
-	assert.Equal(t, dcErr.Code(), codes.AlreadyExists)
+	assert.Equal(t, dcErr.Code().String(), codes.AlreadyExists.String())
 }
 
 func TestListDatasets(t *testing.T) {

--- a/pkg/repositories/gormimpl/tag_test.go
+++ b/pkg/repositories/gormimpl/tag_test.go
@@ -43,10 +43,7 @@ func (p *pgError) Unwrap() error {
 }
 
 func getAlreadyExistsErr() error {
-	return &pgError{
-		e:   &pgconn.PgError{Code: "23505"},
-		msg: "some error",
-	}
+	return &pgconn.PgError{Code: "23505"}
 }
 
 func getTestTag() models.Tag {
@@ -157,5 +154,5 @@ func TestTagAlreadyExists(t *testing.T) {
 	assert.Error(t, err)
 	dcErr, ok := err.(datacatalog_error.DataCatalogError)
 	assert.True(t, ok)
-	assert.Equal(t, dcErr.Code(), codes.AlreadyExists)
+	assert.Equal(t, dcErr.Code().String(), codes.AlreadyExists.String())
 }

--- a/pkg/repositories/gormimpl/tag_test.go
+++ b/pkg/repositories/gormimpl/tag_test.go
@@ -43,7 +43,10 @@ func (p *pgError) Unwrap() error {
 }
 
 func getAlreadyExistsErr() error {
-	return &pgconn.PgError{Code: "23505"}
+	return &pgError{
+		e:   &pgconn.PgError{Code: "23505"},
+		msg: "some error",
+	}
 }
 
 func getTestTag() models.Tag {


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
After gorm upgrade, gorm error type check was no longer valid. This PR changes the error type we cast to and adds some log lines to make it easier to detect this in the future...

Verified connection issue explained here https://github.com/flyteorg/datacatalog/pull/45/files by doing the following:

1. Start a sandbox cluster `flytectl sandbox start`
1. Replace datacatalog deployment image with one built from this PR `kubectl edit deploy -n flyte datacatalog`
1. Login to postgres and drop `datacatalog` db:

    ```sql
     SELECT pg_terminate_backend (pid)
     FROM pg_stat_activity
     WHERE pg_stat_activity.datname = 'datacatalog';

    DROP Database Datacatalog;
    ```

1. Kill datacatalog pod (or roll the deployment) `kubectl delete pod -n flyte <datacatalog pod>`
1. Wait for a new one to start and login to the postgres server once more to verify it recreated the database `\l`

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1414
