### PR TITLE
Trim whitespace for password #patch

### DIFF
--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	dbconfig "github.com/flyteorg/datacatalog/pkg/repositories/config"
 	"github.com/flyteorg/datacatalog/pkg/runtime/configs"
@@ -38,7 +39,7 @@ func (p *ApplicationConfigurationProvider) GetDbConfig() dbconfig.DbConfig {
 			logger.Fatalf(context.Background(), "failed to read database password from path [%s] with err: %v",
 				dbConfigSection.PasswordPath, err)
 		}
-		password = string(passwordVal)
+		password = strings.TrimSpace(string(passwordVal))
 	}
 
 	return dbconfig.DbConfig{

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -39,6 +39,8 @@ func (p *ApplicationConfigurationProvider) GetDbConfig() dbconfig.DbConfig {
 			logger.Fatalf(context.Background(), "failed to read database password from path [%s] with err: %v",
 				dbConfigSection.PasswordPath, err)
 		}
+		// Passwords can contain special characters as long as they are percent encoded
+		// https://www.postgresql.org/docs/current/libpq-connect.html
 		password = strings.TrimSpace(string(passwordVal))
 	}
 


### PR DESCRIPTION
Signed-off-by: stephen batifol <stephen.batifol@wolt.com>

# TL;DR
When deploying Flyte on our EKS cluster, we encountered a problem because we had a whitespace character, by trimming space, we should avoid that problem. Also it doesn't trim space if it is percent-encoded.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Use the function [`TrimSpace`](https://pkg.go.dev/strings#TrimSpace) that "_returns a slice of the string s, with all leading and trailing white space removed, as defined by Unicode._"

## Tracking Issue
I had written something about it in a discussion here https://github.com/flyteorg/flyte/discussions/1472 
