### PR TITLE
Report error on create uuid-ossp extension during postgres migration

### DIFF
--- a/pkg/repositories/handle.go
+++ b/pkg/repositories/handle.go
@@ -71,8 +71,12 @@ func (h *DBHandle) CreateDB(dbName string) error {
 func (h *DBHandle) Migrate(ctx context.Context) error {
 	if h.db.Config.Dialector.Name() == config.Postgres {
 		logger.Infof(ctx, "Creating postgres extension uuid-ossp if it does not exist")
-		h.db.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"")
+		result := h.db.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"")
+		if result.Error != nil {
+			return result.Error
+		}
 	}
+
 	if err := h.db.AutoMigrate(&models.Dataset{}); err != nil {
 		return err
 	}


### PR DESCRIPTION
# TL;DR
Capturing the result of the aforementioned call and failing if it is an error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Currently we are not capturing the result of the `create uuid-ossp extension` call. The migration process may fail with "Failed to migrate. err: ERROR: function uuid_generate_v4() does not exist (SQLSTATE 42883)" which does not capture the actual failure issue, rather a consequence of the missing uuid-ossp extension (which provides the uuid_generate_v4 function).

Some users have discovered this an reverted to manually creating the missing extension, this should not be required or expected.

## Tracking Issue
_NA_

## Follow-up issue
_NA_